### PR TITLE
Add support for custom hooks

### DIFF
--- a/generators/generate-st.py
+++ b/generators/generate-st.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import json
 from os.path import expanduser
 with open(expanduser('~/.cache/wal/colors.json')) as raw_json:
@@ -19,4 +20,6 @@ unsigned int defaultfg = 257;
 unsigned int defaultcs = 258;
 unsigned int defaultrcs= 258;
 """
-print(header)
+with open(expanduser('~/.cache/wal/colors-wal-st.h'), 'w') as colors:
+    colors.write(header)
+

--- a/generators/generate-st.py
+++ b/generators/generate-st.py
@@ -1,0 +1,22 @@
+import json
+from os.path import expanduser
+with open(expanduser('~/.cache/wal/colors.json')) as raw_json:
+    lule_json = json.load(raw_json)
+first16 = []
+for i in range(0, 17):
+    first16.append(lule_json['colors'][f'color{i}'])
+header = ""
+header += "const char *colorname[] = {"
+for index, color in enumerate(first16):
+    header += f"[{index}] = \"{color}\", \n"
+header += """
+[256] = "#000000",
+[257] = "#f4f4f4",
+[258] = "#f4f4f4"
+};
+unsigned int defaultbg = 0;
+unsigned int defaultfg = 257;
+unsigned int defaultcs = 258;
+unsigned int defaultrcs= 258;
+"""
+print(header)

--- a/lule_colors
+++ b/lule_colors
@@ -20,8 +20,22 @@ colors_to_nvim(){
     fi
 }
 # colors_to_nvim &
+run_hooks() {
+    if [ -d $XDG_CONFIG_DIR/lule/hooks ]; then
+        for hook in `find $XDG_CONFIG_DIR/lule/hooks -type f`; do
+            echo Running "$hook"
+            $hook;
+        done
+    elif [ -d ~/.config/lule/hooks ]; then
+        for hook in `find ~/.config/lule/hooks -type f`; do
+            echo Running "$hook"
+            $hook;
+        done
+    else
+        echo "No hook directory found";
+    fi
+}
 
-
-
+run_hooks &
 #apply all colors to firefox needs 'pip install pywalfox'
 # python $HOME/.local/bin/pywalfox update &

--- a/lule_colors
+++ b/lule_colors
@@ -31,6 +31,10 @@ run_hooks() {
             echo Running "$hook"
             $hook;
         done
+    elif [ -d /usr/share/lule/generators ]; then
+        for hook in `find /usr/share/lule/generators -type f`; do
+            echo Running "$hook"
+            $hook;
     else
         echo "No hook directory found";
     fi


### PR DESCRIPTION
This adds support for the user to add a hook in any one of these directories:
- `$XDG_CONFIG_DIR/lule/hooks`
- `~/.config/lule/hooks`
- `/usr/share/lule/generators`
This also adds my custom hook to make a st header file, since pywal can do it, I want lule to as well.