### PR TITLE
Fix color formatting logic in show_colors

### DIFF
--- a/src/show/format.rs
+++ b/src/show/format.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 pub fn show_colors(scheme: &Scheme, colrange: Range<usize>, padding: usize) {
     let colors = scheme.colors().clone().unwrap();
     for i in colrange {
-        let val = if true {
+        let val = if padding == 0 {
             format!("  {:#03}  ", i)
         } else {
             format!(


### PR DESCRIPTION
The `show_colors` function had a hardcoded `if true` block which prevented the actual color hex string and padding logic from being executed. This PR replaces the hardcoded condition with a check on `padding == 0` to allow both index-based display (when no padding is requested) and color-based display (when padding is provided), matching the intended behavior.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.